### PR TITLE
Make pprof listen on 127.0.0.1 by default 

### DIFF
--- a/docker-compose-allinone.yml
+++ b/docker-compose-allinone.yml
@@ -77,7 +77,7 @@ services:
     volumes:
       - ./hagall-private.key:/hagall-private.key:ro
     ports:
-      - 18190:18190
+      - 127.0.0.1:18190:18190
     environment:
       VIRTUAL_HOST: example.com
       VIRTUAL_PORT: 8080


### PR DESCRIPTION
adding loopback as pprof listen address to avoid accidentally exposing debug info on poorly configured nodes.